### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Go Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/TurnipXenon/cherry_backend/security/code-scanning/2](https://github.com/TurnipXenon/cherry_backend/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` key at the root of the workflow (above the `jobs:` key), which will apply to all jobs in this workflow. Since the workflow only checks out code and runs tests, it requires only read access to repository contents. Therefore, the `permissions` key should be set as follows:
```yaml
permissions:
  contents: read
```
This change is made by inserting the `permissions:` block after the `name:` line and before the `on:` block in `.github/workflows/go-tests.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
