### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -8,6 +8,9 @@ on:
       - 'docs/**'
       - '.github/workflows/mkdocs-deploy.yml'
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TurnipXenon/cherry_backend/security/code-scanning/3](https://github.com/TurnipXenon/cherry_backend/security/code-scanning/3)

To fix the issue, we need to explicitly define the `permissions` key in the workflow to restrict access to only what is necessary. In this case:

1. The workflow interacts with the repository contents during the deployment process (e.g., reading and writing to GitHub Pages). The `contents: write` permission is required for deploying to GitHub Pages.
2. Other permissions, like `pull-requests: write`, are not needed, so they should not be included.

The `permissions` key should be added at the root level of the workflow, which will apply to all jobs. This ensures that the `GITHUB_TOKEN` used in the workflow has only the required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
